### PR TITLE
Don't pass constraints to create{Offer,Answer}

### DIFF
--- a/client/webrtc-peer.js
+++ b/client/webrtc-peer.js
@@ -68,9 +68,7 @@ define(['module'], function(module) {
         };
         xhr.send(JSON.stringify({offer: rtc_offer.sdp}));
       },
-                           function(err) { fail(err); },
-                           //XXX: constraints should be optional
-                           {mandatory: {}, optional: []});
+                           function(err) { fail(err); });
     }, function(err) { fail(err); });
   }
 
@@ -130,9 +128,7 @@ define(['module'], function(module) {
                 };
                 postXhr.send(JSON.stringify({value: rtc_answer.sdp}));
               }, function(err) { fail(err); });
-            }, function(err) { fail(err); },
-                                   //XXX: constraints should be optional
-                                   {mandatory: {}, optional: []}, false);
+            }, function(err) { fail(err); });
           },
                                          function(err) { fail(err); });
         }, function(err) { fail(err); });


### PR DESCRIPTION
When we were first hacking on this code there was a bug (bug 805871) that required us to pass the constraints. That's been fixed, so they're no longer necessary. In addition, passing them seems to trigger bug 806407 which makes testing hard. We should just stop passing them.
